### PR TITLE
Export the import of `Synchronization.Mutex` struct

### DIFF
--- a/Sources/SyncPolyfill/Mutex.swift
+++ b/Sources/SyncPolyfill/Mutex.swift
@@ -1,5 +1,5 @@
 #if !canImport(Darwin)
-import Synchronization
+@_exported import struct Synchronization.Mutex
 typealias Mutex = Synchronization.Mutex
 #else
 import Darwin


### PR DESCRIPTION
Allows non-Darwin users (Windows, Linux, etc.) to get access to `Mutex` without having to do this ceremony: 

```swift
#if canImport(Darwin)
import SyncPolyfill
#else
import Synchronization
#endif
```